### PR TITLE
Fix build error by updating dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mapbox-gl": "^3.7.0",
     "marked-react": "^2.0.0",
     "motion": "^11.13.5",
-    "next": "^14.2.20",
+    "next": "^14.2.5",
     "next-themes": "^0.3.0",
     "openai": "^4.56.0",
     "posthog-js": "^1.202.2",
@@ -85,7 +85,8 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "vaul": "^1.1.1",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@ai-sdk/o1": "^1.0.0"
   },
   "devDependencies": {
     "@types/google.maps": "^3.55.12",


### PR DESCRIPTION
Update dependencies in `package.json` to resolve module not found error.

* Update the `next` dependency to version `14.2.5`.
* Add the `@ai-sdk/o1` dependency with version `1.0.0`.

